### PR TITLE
Configurable root node via props

### DIFF
--- a/src/Picker.jsx
+++ b/src/Picker.jsx
@@ -53,6 +53,7 @@ const Picker = React.createClass({
 
   getDefaultProps() {
     return {
+      rootNode: document.body,
       prefixCls: 'rc-calendar-picker',
       adjustOrientOnCalendarOverflow: true,
       style: {},
@@ -198,7 +199,7 @@ const Picker = React.createClass({
     if (!this.calendarContainer) {
       this.calendarContainer = document.createElement('div');
       this.calendarContainer.className = `${this.props.prefixCls}-container`;
-      document.body.appendChild(this.calendarContainer);
+      this.props.rootNode.appendChild(this.calendarContainer);
     }
     return this.calendarContainer;
   },


### PR DESCRIPTION
Using a Picker inside a modal window, there are issues with onBlur events.The calendarContainer is in the document.body and picks a day fires the onBlur's modal window because the calendarContainer is not inside the modal div. This PR adds configuration for the root node to anchor the calendar's container. 

For example:
&lt;Picker rootNode={React.findDOMNode(this.refs.divContainer)} adjustOrientOnCalendarOverflow={true} ... /&gt;
